### PR TITLE
Headers don't have to be black

### DIFF
--- a/dailytags/src/main/java/com/dmytroshuba/dailytags/markdown/styles/Headers.kt
+++ b/dailytags/src/main/java/com/dmytroshuba/dailytags/markdown/styles/Headers.kt
@@ -8,37 +8,31 @@ import androidx.compose.ui.unit.sp
 object Headers {
 
     val h1: SpanStyle = SpanStyle(
-        color = Color.Black,
         fontSize = 72.sp,
         fontWeight = FontWeight.W700
     )
 
     val h2: SpanStyle = SpanStyle(
-        color = Color.Black,
         fontSize = 56.sp,
         fontWeight = FontWeight.W600
     )
 
     val h3: SpanStyle = SpanStyle(
-        color = Color.Black,
         fontSize = 40.sp,
         fontWeight = FontWeight.W500
     )
 
     val h4: SpanStyle = SpanStyle(
-        color = Color.Black,
         fontSize = 32.sp,
         fontWeight = FontWeight.W500
     )
 
     val h5: SpanStyle = SpanStyle(
-        color = Color.Black,
         fontSize = 24.sp,
         fontWeight = FontWeight.W500
     )
 
     val h6: SpanStyle = SpanStyle(
-        color = Color.Black,
         fontSize = 16.sp,
         fontWeight = FontWeight.W500
     )


### PR DESCRIPTION
Hi, the only change is to delete the color definition from the headers.kt file, so that using the # (headers) markdown doesn't force the text to be black